### PR TITLE
make all-invalid group extensions noticed

### DIFF
--- a/lib/App/Rak.rakumod
+++ b/lib/App/Rak.rakumod
@@ -1428,7 +1428,7 @@ my sub option-extensions($value --> Nil) {
       if Bool.ACCEPTS($value);
 
     my @unknown;
-    if $value.split(',').map: {
+    given $value.split(',').map: {
         if .starts-with('#') {
             if %exts{$_} -> \extensions {
                 extensions.Slip


### PR DESCRIPTION
hi,

before
```plain
rak this --extensions=#bad
rak this --extensions=#bad,#another
```
was detecting but ignoring the unknown group extensions, and performing a search with `@known-extensions`. This was the case only if *all* supplied extensions are invalid groups as `.map` was producing an empty Seq and then failing with the `if`. That `if` is now `given` :) Now it reports the unknown groups, e.g., *No extensions known for '#bad #another'.* and exits.