### PR TITLE
Make is-text not default to True if find is set.

### DIFF
--- a/lib/App/Rak.rakumod
+++ b/lib/App/Rak.rakumod
@@ -2309,7 +2309,7 @@ my sub move-filesystem-options-to-rak(--> Nil) {
     %rak<is-text> := True
       unless $reading-from-stdin || (%rak<
         file is-text under-version-control
-      >:k);
+      >:k) || %result<find>;
 }
 
 my sub move-result-options-to-rak(--> Nil) {


### PR DESCRIPTION
Hello,

this modification would keep `is-text` False if it's unspecified and `find` is set to True. That's what I would call the "least surprising" and most useful default: like `find .`, it doesn't have to look into the files to produce a list of them. Those who do want to get only text files, can still specify --is-text no problem. :P