### PR TITLE
feat:Added WL and R extensions rules.

### DIFF
--- a/doc/App-Rak.rakudoc
+++ b/doc/App-Rak.rakudoc
@@ -864,8 +864,8 @@ $ rak foo --extensions=,foo
 =end code
 
 Predefined groups are C<#raku>, C<#perl>, C<#cro>, C<#text>, C<#c>, C<#c++>,
-C<#yaml>, C<#ruby>, C<#python>, C<#html>, C<#markdown>, C<#js>, C<#json>,
-C<#jsonl>, C<#csv>, C<#config> and C<#text>.
+C<#yaml>, C<#ruby>, C<#python>, C<#r>, C<#wl>, C<#html>, C<#markdown>, C<#js>, C<#json>,
+C<#jsonl>, C<#csv>, C<#config>, and C<#text>.
 
 The C<--list-known-extensions> argument can be used to see which predefined
 groups of extensions are supported, and which extensions they cover.
@@ -1455,9 +1455,11 @@ $ rak --list-known-extensions
 #markdown: md markdown
     #perl: (none) pl pm t
   #python: py ipynb
+       #r: (none) r R Rmd
     #raku: (none) raku rakumod rakutest rakudoc nqp t pm6 pl6 pod6 t6
     #ruby: rb
     #text: (none) txt
+      #wl: (none) wl m wlt mt nb
     #yaml: yaml yml
 
 =end code

--- a/lib/App/Rak.rakumod
+++ b/lib/App/Rak.rakumod
@@ -150,6 +150,13 @@ my constant %exts =
   '#python'   => <py ipynb>,
   '#raku'     => ('', <raku rakumod rakutest rakudoc nqp t pm6 pl6 pod6 t6>
                  ).flat.List,
+  # I am not sure should the binary formats be included or not:
+  # https://reference.wolfram.com/language/guide/WolframLanguageFileFormats.html
+  # Also #mathematica can be included as synonym of #wl .
+  '#wl'     => ('', <wl wlt m mt nb>).flat.List,
+  # I am including .Rmd because of .ipynb inclusion above.
+  # More generally, the extensions of the project https://quarto.org should be included.
+  '#r'     => ('', <r R Rmd>).flat.List,
   '#ruby'     => <rb>,
   '#text'     => ('', <txt>).flat.List,
   '#yaml'     => <yaml yml>,


### PR DESCRIPTION
These code changes add extensions specs for Wolfram Language (WL) (`#wl`) and R (`#r`). 
I am not sure should we have the synonym `#mathematica` of `#wl`.